### PR TITLE
Add CRUD services for files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,18 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk</artifactId>
+            <version>1.11.728</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/team4/testingsystem/config/AmazonS3Configuration.java
+++ b/src/main/java/com/team4/testingsystem/config/AmazonS3Configuration.java
@@ -1,0 +1,32 @@
+package com.team4.testingsystem.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AmazonS3Configuration {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String awsAccessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String awsSecretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/team4/testingsystem/config/WebSecurityConfiguration.java
+++ b/src/main/java/com/team4/testingsystem/config/WebSecurityConfiguration.java
@@ -45,7 +45,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
         }
 
         http.authorizeRequests()
-                .antMatchers("**").permitAll()
+                .antMatchers("/").permitAll()
                 .antMatchers("/login").permitAll()
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/com/team4/testingsystem/config/WebSecurityConfiguration.java
+++ b/src/main/java/com/team4/testingsystem/config/WebSecurityConfiguration.java
@@ -45,7 +45,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
         }
 
         http.authorizeRequests()
-                .antMatchers("/").permitAll()
+                .antMatchers("**").permitAll()
                 .antMatchers("/login").permitAll()
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/com/team4/testingsystem/exceptions/FileDeletingFailedException.java
+++ b/src/main/java/com/team4/testingsystem/exceptions/FileDeletingFailedException.java
@@ -1,0 +1,4 @@
+package com.team4.testingsystem.exceptions;
+
+public class FileDeletingFailedException extends RuntimeException {
+}

--- a/src/main/java/com/team4/testingsystem/exceptions/FileDeletingFailedException.java
+++ b/src/main/java/com/team4/testingsystem/exceptions/FileDeletingFailedException.java
@@ -1,4 +1,8 @@
 package com.team4.testingsystem.exceptions;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR, reason = "File deleting failed")
 public class FileDeletingFailedException extends RuntimeException {
 }

--- a/src/main/java/com/team4/testingsystem/exceptions/FileLoadingFailedException.java
+++ b/src/main/java/com/team4/testingsystem/exceptions/FileLoadingFailedException.java
@@ -1,0 +1,4 @@
+package com.team4.testingsystem.exceptions;
+
+public class FileLoadingFailedException extends RuntimeException {
+}

--- a/src/main/java/com/team4/testingsystem/exceptions/FileLoadingFailedException.java
+++ b/src/main/java/com/team4/testingsystem/exceptions/FileLoadingFailedException.java
@@ -1,4 +1,8 @@
 package com.team4.testingsystem.exceptions;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR, reason = "File loading failed")
 public class FileLoadingFailedException extends RuntimeException {
 }

--- a/src/main/java/com/team4/testingsystem/exceptions/FileSavingFailedException.java
+++ b/src/main/java/com/team4/testingsystem/exceptions/FileSavingFailedException.java
@@ -1,0 +1,4 @@
+package com.team4.testingsystem.exceptions;
+
+public class FileSavingFailedException extends RuntimeException {
+}

--- a/src/main/java/com/team4/testingsystem/exceptions/FileSavingFailedException.java
+++ b/src/main/java/com/team4/testingsystem/exceptions/FileSavingFailedException.java
@@ -1,4 +1,8 @@
 package com.team4.testingsystem.exceptions;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR, reason = "File saving failed")
 public class FileSavingFailedException extends RuntimeException {
 }

--- a/src/main/java/com/team4/testingsystem/repositories/AmazonS3Repository.java
+++ b/src/main/java/com/team4/testingsystem/repositories/AmazonS3Repository.java
@@ -1,0 +1,61 @@
+package com.team4.testingsystem.repositories;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import com.amazonaws.util.IOUtils;
+import com.team4.testingsystem.exceptions.FileLoadingFailedException;
+import com.team4.testingsystem.exceptions.FileSavingFailedException;
+import org.apache.commons.io.FileUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Repository;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Profile("release")
+@Repository
+public class AmazonS3Repository implements FilesRepository {
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.s3.bucket-name}")
+    private String bucketName;
+
+    @Autowired
+    public AmazonS3Repository(AmazonS3 amazonS3) {
+        this.amazonS3 = amazonS3;
+    }
+
+    @Override
+    public void save(String fileName, Resource file) throws FileSavingFailedException {
+        try {
+            Path tempFilePath = Files.createTempFile(null, file.getFilename());
+            File tempFile = new File(tempFilePath.toString());
+
+            FileUtils.copyInputStreamToFile(file.getInputStream(), tempFile);
+            amazonS3.putObject(bucketName, fileName, tempFile);
+            tempFile.deleteOnExit();
+        } catch (IOException | AmazonServiceException e) {
+            throw new FileSavingFailedException();
+        }
+    }
+
+    @Override
+    public Resource load(String fileName) throws FileLoadingFailedException {
+        try {
+            S3Object data = amazonS3.getObject(bucketName, fileName);
+            S3ObjectInputStream objectContent = data.getObjectContent();
+
+            return new ByteArrayResource(IOUtils.toByteArray(objectContent));
+        } catch (IOException | AmazonServiceException e) {
+            throw new FileLoadingFailedException();
+        }
+    }
+}

--- a/src/main/java/com/team4/testingsystem/repositories/AmazonS3Repository.java
+++ b/src/main/java/com/team4/testingsystem/repositories/AmazonS3Repository.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.util.IOUtils;
+import com.team4.testingsystem.exceptions.FileDeletingFailedException;
 import com.team4.testingsystem.exceptions.FileLoadingFailedException;
 import com.team4.testingsystem.exceptions.FileSavingFailedException;
 import org.apache.commons.io.FileUtils;
@@ -36,7 +37,7 @@ public class AmazonS3Repository implements FilesRepository {
     @Override
     public void save(String fileName, Resource file) throws FileSavingFailedException {
         try {
-            Path tempFilePath = Files.createTempFile(null, file.getFilename());
+            Path tempFilePath = createTempFile(fileName);
             File tempFile = new File(tempFilePath.toString());
 
             FileUtils.copyInputStreamToFile(file.getInputStream(), tempFile);
@@ -57,5 +58,18 @@ public class AmazonS3Repository implements FilesRepository {
         } catch (IOException | AmazonServiceException e) {
             throw new FileLoadingFailedException();
         }
+    }
+
+    @Override
+    public void delete(String fileName) throws FileDeletingFailedException {
+        try {
+            amazonS3.deleteObject(bucketName, fileName);
+        } catch (AmazonServiceException e) {
+            throw new FileDeletingFailedException();
+        }
+    }
+
+    public Path createTempFile(String fileName) throws IOException {
+        return Files.createTempFile(null, fileName);
     }
 }

--- a/src/main/java/com/team4/testingsystem/repositories/FileSystemRepository.java
+++ b/src/main/java/com/team4/testingsystem/repositories/FileSystemRepository.java
@@ -1,0 +1,44 @@
+package com.team4.testingsystem.repositories;
+
+import com.team4.testingsystem.exceptions.FileLoadingFailedException;
+import com.team4.testingsystem.exceptions.FileSavingFailedException;
+import org.apache.commons.io.FileUtils;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Repository;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+@Profile("!release")
+@Repository
+public class FileSystemRepository implements FilesRepository {
+    @Override
+    public void save(String fileName, Resource file) throws FileSavingFailedException {
+        Path newFilePath = generateFilePath(fileName);
+
+        try {
+            FileUtils.copyInputStreamToFile(file.getInputStream(), new File(newFilePath.toString()));
+        } catch (IOException e) {
+            throw new FileSavingFailedException();
+        }
+    }
+
+    @Override
+    public Resource load(String fileName) throws FileLoadingFailedException {
+        Path filePath = generateFilePath(fileName);
+        if (Files.notExists(filePath)) {
+            throw new FileLoadingFailedException();
+        }
+
+        return new FileSystemResource(filePath);
+    }
+
+    private Path generateFilePath(String fileName) {
+        return Path.of(FileUtils.getTempDirectory() + "/" + UUID.randomUUID() + "-" + fileName);
+    }
+}

--- a/src/main/java/com/team4/testingsystem/repositories/FileSystemRepository.java
+++ b/src/main/java/com/team4/testingsystem/repositories/FileSystemRepository.java
@@ -53,6 +53,6 @@ public class FileSystemRepository implements FilesRepository {
     }
 
     public Path generateFilePath(String fileName) {
-        return Path.of(FileUtils.getTempDirectory() + "/" + fileName);
+        return Path.of(FileUtils.getTempDirectory() + "/testing-system/" + fileName);
     }
 }

--- a/src/main/java/com/team4/testingsystem/repositories/FileSystemRepository.java
+++ b/src/main/java/com/team4/testingsystem/repositories/FileSystemRepository.java
@@ -7,7 +7,7 @@ import org.apache.commons.io.FileUtils;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
-import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,7 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 @Profile("!release")
-@Repository
+@Service
 public class FileSystemRepository implements FilesRepository {
     @Override
     public void save(String fileName, Resource file) throws FileSavingFailedException {

--- a/src/main/java/com/team4/testingsystem/repositories/FileSystemRepository.java
+++ b/src/main/java/com/team4/testingsystem/repositories/FileSystemRepository.java
@@ -1,5 +1,6 @@
 package com.team4.testingsystem.repositories;
 
+import com.team4.testingsystem.exceptions.FileDeletingFailedException;
 import com.team4.testingsystem.exceptions.FileLoadingFailedException;
 import com.team4.testingsystem.exceptions.FileSavingFailedException;
 import org.apache.commons.io.FileUtils;
@@ -12,7 +13,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.UUID;
 
 @Profile("!release")
 @Repository
@@ -38,7 +38,21 @@ public class FileSystemRepository implements FilesRepository {
         return new FileSystemResource(filePath);
     }
 
-    private Path generateFilePath(String fileName) {
-        return Path.of(FileUtils.getTempDirectory() + "/" + UUID.randomUUID() + "-" + fileName);
+    @Override
+    public void delete(String fileName) {
+        Path filePath = generateFilePath(fileName);
+        if (Files.notExists(filePath)) {
+            return;
+        }
+
+        try {
+            Files.delete(filePath);
+        } catch (IOException e) {
+            throw new FileDeletingFailedException();
+        }
+    }
+
+    public Path generateFilePath(String fileName) {
+        return Path.of(FileUtils.getTempDirectory() + "/" + fileName);
     }
 }

--- a/src/main/java/com/team4/testingsystem/repositories/FilesRepository.java
+++ b/src/main/java/com/team4/testingsystem/repositories/FilesRepository.java
@@ -1,0 +1,13 @@
+package com.team4.testingsystem.repositories;
+
+import com.team4.testingsystem.exceptions.FileLoadingFailedException;
+import com.team4.testingsystem.exceptions.FileSavingFailedException;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FilesRepository {
+    void save(String fileName, Resource file) throws FileSavingFailedException;
+
+    Resource load(String fileName) throws FileLoadingFailedException;
+}

--- a/src/main/java/com/team4/testingsystem/repositories/FilesRepository.java
+++ b/src/main/java/com/team4/testingsystem/repositories/FilesRepository.java
@@ -4,9 +4,7 @@ import com.team4.testingsystem.exceptions.FileDeletingFailedException;
 import com.team4.testingsystem.exceptions.FileLoadingFailedException;
 import com.team4.testingsystem.exceptions.FileSavingFailedException;
 import org.springframework.core.io.Resource;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface FilesRepository {
     void save(String fileName, Resource file) throws FileSavingFailedException;
 

--- a/src/main/java/com/team4/testingsystem/repositories/FilesRepository.java
+++ b/src/main/java/com/team4/testingsystem/repositories/FilesRepository.java
@@ -1,5 +1,6 @@
 package com.team4.testingsystem.repositories;
 
+import com.team4.testingsystem.exceptions.FileDeletingFailedException;
 import com.team4.testingsystem.exceptions.FileLoadingFailedException;
 import com.team4.testingsystem.exceptions.FileSavingFailedException;
 import org.springframework.core.io.Resource;
@@ -10,4 +11,6 @@ public interface FilesRepository {
     void save(String fileName, Resource file) throws FileSavingFailedException;
 
     Resource load(String fileName) throws FileLoadingFailedException;
+
+    void delete(String fileName) throws FileDeletingFailedException;
 }

--- a/src/main/java/com/team4/testingsystem/services/FileStorage.java
+++ b/src/main/java/com/team4/testingsystem/services/FileStorage.java
@@ -1,0 +1,39 @@
+package com.team4.testingsystem.services;
+
+import com.team4.testingsystem.exceptions.FileDeletingFailedException;
+import com.team4.testingsystem.exceptions.FileLoadingFailedException;
+import com.team4.testingsystem.exceptions.FileSavingFailedException;
+import com.team4.testingsystem.repositories.FilesRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class FileStorage {
+    private final FilesRepository filesRepository;
+
+    @Autowired
+    public FileStorage(FilesRepository filesRepository) {
+        this.filesRepository = filesRepository;
+    }
+
+    public String upload(Resource file) throws FileSavingFailedException {
+        String fileUrl = UUID.randomUUID() + "-" + file.getFilename();
+        save(fileUrl, file);
+        return fileUrl;
+    }
+
+    public void save(String fileUrl, Resource file) throws FileSavingFailedException {
+        filesRepository.save(fileUrl, file);
+    }
+
+    public Resource load(String fileUrl) throws FileLoadingFailedException {
+        return filesRepository.load(fileUrl);
+    }
+
+    public void delete(String fileUrl) throws FileDeletingFailedException {
+        filesRepository.delete(fileUrl);
+    }
+}

--- a/src/main/resources/application-release.properties
+++ b/src/main/resources/application-release.properties
@@ -1,3 +1,10 @@
+# Database credentials
 spring.datasource.url=${CLEARDB_DATABASE_URL}
 spring.datasource.username=${CLEARDB_DATABASE_USERNAME}
 spring.datasource.password=${CLEARDB_DATABASE_PASSWORD}
+
+# Amazon S3 credentials
+cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
+cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
+cloud.aws.region.static=eu-central-1
+cloud.s3.bucket-name=untitled-testing-system

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,9 @@ spring.jpa.hibernate.ddl-auto=none
 
 #Disable CSRF token
 csrf-enabled=false
+
+#Amazon S3 credentials
+cloud.aws.credentials.access-key=
+cloud.aws.credentials.secret-key=
+cloud.aws.region.static=eu-central-1
+cloud.s3.bucket-name=untitled-testing-system

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,18 +1,12 @@
-#Liquibase
+# Liquibase
 spring.liquibase.change-log=classpath:db/changelog/db-changelog.xml
 
-#Datasource
+# Datasource
 spring.datasource.url=jdbc:mysql://localhost:3306/language_testing
 spring.datasource.username=root
 spring.datasource.password=root
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=none
 
-#Disable CSRF token
+# Disable CSRF token
 csrf-enabled=false
-
-#Amazon S3 credentials
-cloud.aws.credentials.access-key=
-cloud.aws.credentials.secret-key=
-cloud.aws.region.static=eu-central-1
-cloud.s3.bucket-name=untitled-testing-system

--- a/src/test/java/com/team4/testingsystem/repositories/AmazonS3RepositoryTest.java
+++ b/src/test/java/com/team4/testingsystem/repositories/AmazonS3RepositoryTest.java
@@ -1,0 +1,141 @@
+package com.team4.testingsystem.repositories;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.S3Object;
+import com.team4.testingsystem.exceptions.FileDeletingFailedException;
+import com.team4.testingsystem.exceptions.FileLoadingFailedException;
+import com.team4.testingsystem.exceptions.FileSavingFailedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@ExtendWith(MockitoExtension.class)
+class AmazonS3RepositoryTest {
+    @Mock
+    private AmazonS3 amazonS3;
+
+    @InjectMocks
+    private AmazonS3Repository amazonS3Repository;
+
+    @Value("${cloud.s3.bucket-name}")
+    private String bucketName;
+
+    private static final String SOURCE_FILE_NAME = "source_file.txt";
+    private static final String FILE_NAME = "test_file.txt";
+    private static final String TEST_CONTENT = "test content";
+
+    private static final Path SOURCE_FILE_PATH = Path.of(SOURCE_FILE_NAME);
+    private static final Path FILE_PATH = Path.of(FILE_NAME);
+
+    private FileSystemResource sourceFile;
+
+    @BeforeEach
+    void init() {
+        amazonS3Repository = new AmazonS3Repository(amazonS3);
+
+        try {
+            Files.writeString(SOURCE_FILE_PATH, TEST_CONTENT);
+        } catch (IOException e) {
+            Assertions.fail();
+        }
+
+        sourceFile = new FileSystemResource(SOURCE_FILE_NAME);
+    }
+
+    @AfterEach
+    void destroy() {
+        try {
+            Files.deleteIfExists(FILE_PATH);
+            Files.delete(SOURCE_FILE_PATH);
+        } catch (IOException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void saveFail() {
+        ArgumentCaptor<File> fileArgumentCaptor = ArgumentCaptor.forClass(File.class);
+        Mockito.when(amazonS3.putObject(
+                Mockito.eq(bucketName),
+                Mockito.eq(FILE_NAME),
+                fileArgumentCaptor.capture())
+        ).thenThrow(new AmazonServiceException(""));
+
+        Assertions.assertThrows(FileSavingFailedException.class,
+                () -> amazonS3Repository.save(FILE_NAME, sourceFile));
+    }
+
+    @Test
+    void saveSuccess() throws IOException {
+        AmazonS3Repository spyRepository = Mockito.spy(amazonS3Repository);
+        Mockito.when(spyRepository.createTempFile(FILE_NAME)).thenReturn(FILE_PATH);
+
+        spyRepository.save(FILE_NAME, sourceFile);
+
+        ArgumentCaptor<File> fileArgumentCaptor = ArgumentCaptor.forClass(File.class);
+        Mockito.verify(amazonS3).putObject(
+                Mockito.eq(bucketName),
+                Mockito.eq(FILE_NAME),
+                fileArgumentCaptor.capture()
+        );
+
+        Assertions.assertEquals(FILE_PATH.toString(), fileArgumentCaptor.getValue().getPath());
+        try {
+            Assertions.assertEquals(TEST_CONTENT, Files.readString(FILE_PATH));
+        } catch (IOException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void loadFail() {
+        Mockito.when(amazonS3.getObject(bucketName, FILE_NAME))
+                .thenThrow(new AmazonServiceException(""));
+
+        Assertions.assertThrows(FileLoadingFailedException.class,
+                () -> amazonS3Repository.load(FILE_NAME));
+    }
+
+    @Test
+    void loadSuccess() throws IOException {
+        S3Object s3Object = new S3Object();
+        s3Object.setObjectContent(sourceFile.getInputStream());
+
+        Mockito.when(amazonS3.getObject(bucketName, FILE_NAME)).thenReturn(s3Object);
+
+        Assertions.assertArrayEquals(TEST_CONTENT.getBytes(StandardCharsets.UTF_8),
+                amazonS3Repository.load(FILE_NAME).getInputStream().readAllBytes());
+    }
+
+    @Test
+    void deleteFail() {
+        Mockito.doThrow(new AmazonServiceException(""))
+                .when(amazonS3).deleteObject(bucketName, FILE_NAME);
+
+        Assertions.assertThrows(FileDeletingFailedException.class,
+                () -> amazonS3Repository.delete(FILE_NAME));
+    }
+
+    @Test
+    void deleteSuccess() {
+        Mockito.doNothing().when(amazonS3).deleteObject(bucketName, FILE_NAME);
+
+        Assertions.assertDoesNotThrow(() -> amazonS3Repository.delete(FILE_NAME));
+    }
+}

--- a/src/test/java/com/team4/testingsystem/repositories/FileSystemRepositoryTest.java
+++ b/src/test/java/com/team4/testingsystem/repositories/FileSystemRepositoryTest.java
@@ -1,0 +1,162 @@
+package com.team4.testingsystem.repositories;
+
+import com.team4.testingsystem.exceptions.FileLoadingFailedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.FileSystemResource;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@ExtendWith(MockitoExtension.class)
+class FileSystemRepositoryTest {
+    @Spy
+    private FileSystemRepository fileSystemRepository;
+
+    private static final String SOURCE_FILE_NAME = "source_file.txt";
+    private static final String FILE_NAME = "test_file.txt";
+    private static final String TEST_CONTENT = "test content";
+
+    private static final Path SOURCE_FILE_PATH = Path.of(SOURCE_FILE_NAME);
+    private static final Path FILE_PATH = Path.of(FILE_NAME);
+
+    private FileSystemResource sourceFile;
+
+    @BeforeEach
+    void init() {
+        try {
+            Files.writeString(SOURCE_FILE_PATH, TEST_CONTENT);
+        } catch (IOException e) {
+            Assertions.fail();
+        }
+
+        sourceFile = new FileSystemResource(SOURCE_FILE_NAME);
+    }
+
+    @AfterEach
+    void destroy() {
+        try {
+            Files.deleteIfExists(FILE_PATH);
+            Files.delete(SOURCE_FILE_PATH);
+        } catch (IOException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void saveFileSuccess() {
+        Mockito.when(fileSystemRepository.generateFilePath(FILE_NAME)).thenReturn(FILE_PATH);
+
+        fileSystemRepository.save(FILE_NAME, sourceFile);
+
+        Assertions.assertTrue(Files.exists(FILE_PATH));
+        try {
+            Assertions.assertEquals(TEST_CONTENT, Files.readString(FILE_PATH));
+        } catch (IOException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void saveFileAlreadyExists() {
+        Mockito.when(fileSystemRepository.generateFilePath(FILE_NAME)).thenReturn(FILE_PATH);
+        try {
+            Files.writeString(FILE_PATH, TEST_CONTENT + TEST_CONTENT);
+        } catch (IOException e) {
+            Assertions.fail();
+        }
+
+        Assertions.assertDoesNotThrow(() -> fileSystemRepository.save(FILE_NAME, sourceFile));
+
+        Assertions.assertTrue(Files.exists(FILE_PATH));
+        try {
+            Assertions.assertEquals(TEST_CONTENT, Files.readString(FILE_PATH));
+        } catch (IOException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void saveFileDirectoryNotExists() {
+        Path nonExistingPath = Path.of("non-existing-dir/" + FILE_NAME);
+        Mockito.when(fileSystemRepository.generateFilePath(FILE_NAME)).thenReturn(nonExistingPath);
+
+        Assertions.assertDoesNotThrow(() -> fileSystemRepository.save(FILE_NAME, sourceFile));
+
+        Assertions.assertTrue(Files.exists(nonExistingPath));
+
+        try {
+            Files.delete(nonExistingPath);
+            Files.delete(nonExistingPath.getParent());
+        } catch (IOException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void loadFileNotExists() {
+        Mockito.when(fileSystemRepository.generateFilePath(FILE_NAME)).thenReturn(FILE_PATH);
+
+        Assertions.assertThrows(FileLoadingFailedException.class,
+                () -> fileSystemRepository.load(FILE_NAME));
+    }
+
+    @Test
+    void loadFileSuccess() {
+        Mockito.when(fileSystemRepository.generateFilePath(FILE_NAME)).thenReturn(FILE_PATH);
+        try {
+            Files.writeString(FILE_PATH, TEST_CONTENT);
+        } catch (IOException e) {
+            Assertions.fail();
+        }
+
+        try {
+            Assertions.assertArrayEquals(TEST_CONTENT.getBytes(StandardCharsets.UTF_8),
+                    fileSystemRepository.load(FILE_NAME).getInputStream().readAllBytes());
+        } catch (IOException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void deleteFileNotExists() {
+        Mockito.when(fileSystemRepository.generateFilePath(FILE_NAME)).thenReturn(FILE_PATH);
+
+        Assertions.assertDoesNotThrow(() -> fileSystemRepository.delete(FILE_NAME));
+    }
+
+    @Test
+    void deleteFileSuccess() {
+        Mockito.when(fileSystemRepository.generateFilePath(FILE_NAME)).thenReturn(FILE_PATH);
+        try {
+            Files.writeString(FILE_PATH, TEST_CONTENT);
+        } catch (IOException e) {
+            Assertions.fail();
+        }
+
+        Assertions.assertDoesNotThrow(() -> fileSystemRepository.delete(FILE_NAME));
+        Assertions.assertTrue(Files.notExists(FILE_PATH));
+    }
+
+    @Test
+    void saveLoadDelete() {
+        Assertions.assertDoesNotThrow(() -> fileSystemRepository.save(FILE_NAME, sourceFile));
+
+        try {
+            Assertions.assertArrayEquals(TEST_CONTENT.getBytes(StandardCharsets.UTF_8),
+                    fileSystemRepository.load(FILE_NAME).getInputStream().readAllBytes());
+        } catch (IOException e) {
+            Assertions.fail();
+        }
+
+        Assertions.assertDoesNotThrow(() -> fileSystemRepository.delete(FILE_NAME));
+    }
+}

--- a/src/test/java/com/team4/testingsystem/services/FileStorageTest.java
+++ b/src/test/java/com/team4/testingsystem/services/FileStorageTest.java
@@ -1,0 +1,105 @@
+package com.team4.testingsystem.services;
+
+import com.team4.testingsystem.exceptions.FileDeletingFailedException;
+import com.team4.testingsystem.exceptions.FileLoadingFailedException;
+import com.team4.testingsystem.exceptions.FileSavingFailedException;
+import com.team4.testingsystem.repositories.FilesRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.FileSystemResource;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@ExtendWith(MockitoExtension.class)
+class FileStorageTest {
+    @Mock
+    private FilesRepository filesRepository;
+
+    @InjectMocks
+    private FileStorage fileStorage;
+
+    private static final String SOURCE_FILE_NAME = "source_file.txt";
+
+    private static final Path SOURCE_FILE_PATH = Path.of(SOURCE_FILE_NAME);
+
+    private FileSystemResource sourceFile;
+
+    @BeforeEach
+    void init() {
+        try {
+            Files.createFile(SOURCE_FILE_PATH);
+        } catch (IOException e) {
+            Assertions.fail();
+        }
+
+        sourceFile = new FileSystemResource(SOURCE_FILE_NAME);
+    }
+
+    @AfterEach
+    void destroy() {
+        try {
+            Files.delete(SOURCE_FILE_PATH);
+        } catch (IOException e) {
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    void uploadFailed() {
+        Mockito.doThrow(new FileSavingFailedException()).when(filesRepository)
+                .save(Mockito.contains(SOURCE_FILE_NAME), Mockito.eq(sourceFile));
+
+        Assertions.assertThrows(FileSavingFailedException.class,
+                () -> fileStorage.upload(sourceFile));
+    }
+
+    @Test
+    void uploadSuccess() {
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        Mockito.doNothing().when(filesRepository)
+                .save(captor.capture(), Mockito.eq(sourceFile));
+
+        String fileUrl = fileStorage.upload(sourceFile);
+        Assertions.assertEquals(fileUrl, captor.getValue());
+    }
+
+    @Test
+    void loadFailed() {
+        Mockito.when(filesRepository.load(SOURCE_FILE_NAME))
+                .thenThrow(new FileLoadingFailedException());
+
+        Assertions.assertThrows(FileLoadingFailedException.class,
+                () -> fileStorage.load(SOURCE_FILE_NAME));
+    }
+
+    @Test
+    void loadSuccess() {
+        Mockito.when(filesRepository.load(SOURCE_FILE_NAME)).thenReturn(sourceFile);
+        Assertions.assertEquals(sourceFile, filesRepository.load(SOURCE_FILE_NAME));
+    }
+
+    @Test
+    void deleteFailed() {
+        Mockito.doThrow(new FileDeletingFailedException())
+                .when(filesRepository).delete(SOURCE_FILE_NAME);
+
+        Assertions.assertThrows(FileDeletingFailedException.class,
+                () -> fileStorage.delete(SOURCE_FILE_NAME));
+    }
+
+    @Test
+    void deleteSuccess() {
+        Mockito.doNothing().when(filesRepository).delete(SOURCE_FILE_NAME);
+        Assertions.assertDoesNotThrow(() -> fileStorage.delete(SOURCE_FILE_NAME));
+    }
+}


### PR DESCRIPTION
Provide two implementations of file storage:
* **FileSystem** - files are stored in temp directory
* **AmazonS3** - files are uploaded to Amazon S3 service

Amazon S3 is enabled only when `release` spring profile is active.