### PR TITLE
Configure PITest maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,8 +274,8 @@
                         <param>com.team4.testingsystem.entities.*</param>
                         <param>com.team4.testingsystem.dto.*</param>
                     </excludedClasses>
-                    <mutationThreshold>60</mutationThreshold>
-                    <coverageThreshold>70</coverageThreshold>
+                    <mutationThreshold>75</mutationThreshold>
+                    <coverageThreshold>90</coverageThreshold>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,7 @@
                     <excludedClasses>
                         <param>com.team4.testingsystem.entities.*</param>
                         <param>com.team4.testingsystem.dto.*</param>
+                        <param>com.team4.testingsystem.config.*</param>
                     </excludedClasses>
                     <mutationThreshold>75</mutationThreshold>
                     <coverageThreshold>90</coverageThreshold>

--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <phase>test</phase>
+                        <phase>verify</phase>
                         <goals>
                             <goal>mutationCoverage</goal>
                         </goals>


### PR DESCRIPTION
* Increase code coverage threshold up to 90%
* Increase mutation coverage threshold up to 75%
* Exclude classes from `config` package
* Change execution phase to `verify`, so that other plugins run before PITest