### PR TITLE
Restrictions: questions controller

### DIFF
--- a/src/main/java/com/team4/testingsystem/exceptions/AnswersAreBadException.java
+++ b/src/main/java/com/team4/testingsystem/exceptions/AnswersAreBadException.java
@@ -1,0 +1,7 @@
+package com.team4.testingsystem.exceptions;
+
+public class AnswersAreBadException extends RuntimeException {
+    public AnswersAreBadException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/team4/testingsystem/exceptions/ControllerAdvice.java
+++ b/src/main/java/com/team4/testingsystem/exceptions/ControllerAdvice.java
@@ -72,4 +72,12 @@ public class ControllerAdvice extends ResponseEntityExceptionHandler {
     public ErrorResponse handleIllegalGradeException(IllegalGradeException e) {
         return new ErrorResponse(e.getMessage());
     }
+
+    @ExceptionHandler(value = {AnswersAreBadException.class})
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleAnswersAreBadException(AnswersAreBadException e) {
+        return new ErrorResponse(e.getMessage());
+    }
+
+
 }

--- a/src/main/java/com/team4/testingsystem/exceptions/QuestionOrTopicEditingException.java
+++ b/src/main/java/com/team4/testingsystem/exceptions/QuestionOrTopicEditingException.java
@@ -1,0 +1,7 @@
+package com.team4.testingsystem.exceptions;
+
+public class QuestionOrTopicEditingException extends ConflictException {
+    public QuestionOrTopicEditingException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/team4/testingsystem/services/ContentFilesService.java
+++ b/src/main/java/com/team4/testingsystem/services/ContentFilesService.java
@@ -11,7 +11,7 @@ public interface ContentFilesService {
 
     ContentFile add(MultipartFile file, ContentFile contentFile);
 
-    ContentFile update(MultipartFile file, Long id, ContentFile contentFile);
+    ContentFile update(MultipartFile file, Long id, ContentFile editedContentFile);
 
     void updateURL(Long id, String newUrl);
 

--- a/src/main/java/com/team4/testingsystem/services/QuestionService.java
+++ b/src/main/java/com/team4/testingsystem/services/QuestionService.java
@@ -17,7 +17,7 @@ public interface QuestionService {
 
     void updateAvailability(Long id, boolean available);
 
-    Question updateQuestion(Question question, Long id);
+    Question updateQuestion(Question editedQuestion, Long id);
 
     List<Question> getRandomQuestions(String level, String module, Pageable pageable);
 

--- a/src/main/java/com/team4/testingsystem/services/RestrictionsService.java
+++ b/src/main/java/com/team4/testingsystem/services/RestrictionsService.java
@@ -1,6 +1,7 @@
 package com.team4.testingsystem.services;
 
 import com.team4.testingsystem.entities.Answer;
+import com.team4.testingsystem.entities.ContentFile;
 import com.team4.testingsystem.entities.Question;
 import com.team4.testingsystem.entities.Test;
 import com.team4.testingsystem.entities.User;
@@ -47,6 +48,10 @@ public interface RestrictionsService {
     void checkModuleIsNotListening(Question question);
 
     void checkAnswersAreCorrect(List<Answer> answers);
+
+    void checkNotArchivedQuestion(Question question);
+
+    void checkNotArchivedContentFile(ContentFile contentFile);
 
 
 }

--- a/src/main/java/com/team4/testingsystem/services/RestrictionsService.java
+++ b/src/main/java/com/team4/testingsystem/services/RestrictionsService.java
@@ -1,9 +1,12 @@
 package com.team4.testingsystem.services;
 
+import com.team4.testingsystem.entities.Answer;
 import com.team4.testingsystem.entities.Question;
 import com.team4.testingsystem.entities.Test;
 import com.team4.testingsystem.entities.User;
 import com.team4.testingsystem.enums.Status;
+
+import java.util.List;
 
 public interface RestrictionsService {
 
@@ -40,5 +43,10 @@ public interface RestrictionsService {
     void checkNotSelfAssignAdmin(Test test);
 
     void checkNotSelfDeassignAdmin(Test test);
+
+    void checkModuleIsNotListening(Question question);
+
+    void checkAnswersAreCorrect(List<Answer> answers);
+
 
 }

--- a/src/main/java/com/team4/testingsystem/services/impl/QuestionServiceImpl.java
+++ b/src/main/java/com/team4/testingsystem/services/impl/QuestionServiceImpl.java
@@ -68,9 +68,13 @@ public class QuestionServiceImpl implements QuestionService {
 
     @Transactional
     @Override
-    public Question updateQuestion(Question question, Long id) {
+    public Question updateQuestion(Question editedQuestion, Long id) {
+        Question question = getById(id);
+
+        restrictionsService.checkNotArchivedQuestion(question);
+
         questionRepository.updateAvailability(id, false);
-        return questionRepository.save(question);
+        return questionRepository.save(editedQuestion);
     }
 
     @Override

--- a/src/main/java/com/team4/testingsystem/services/impl/QuestionServiceImpl.java
+++ b/src/main/java/com/team4/testingsystem/services/impl/QuestionServiceImpl.java
@@ -12,6 +12,7 @@ import com.team4.testingsystem.exceptions.QuestionNotFoundException;
 import com.team4.testingsystem.repositories.ContentFilesRepository;
 import com.team4.testingsystem.repositories.QuestionRepository;
 import com.team4.testingsystem.services.QuestionService;
+import com.team4.testingsystem.services.RestrictionsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -25,12 +26,15 @@ public class QuestionServiceImpl implements QuestionService {
 
     private final QuestionRepository questionRepository;
     private final ContentFilesRepository contentFilesRepository;
+    private final RestrictionsService restrictionsService;
 
     @Autowired
     QuestionServiceImpl(QuestionRepository questionRepository,
-                        ContentFilesRepository contentFilesRepository) {
+                        ContentFilesRepository contentFilesRepository,
+                        RestrictionsService restrictionsService) {
         this.questionRepository = questionRepository;
         this.contentFilesRepository = contentFilesRepository;
+        this.restrictionsService = restrictionsService;
     }
 
     @Override
@@ -49,6 +53,7 @@ public class QuestionServiceImpl implements QuestionService {
         List<Answer> answers = textAnswers.stream()
                 .map(answerDTO -> new Answer(answerDTO, question))
                 .collect(Collectors.toList());
+        restrictionsService.checkAnswersAreCorrect(answers);
         question.setAnswers(answers);
         return questionRepository.save(question);
     }
@@ -56,6 +61,8 @@ public class QuestionServiceImpl implements QuestionService {
     @Transactional
     @Override
     public void updateAvailability(Long id, boolean available) {
+        Question question = getById(id);
+        restrictionsService.checkModuleIsNotListening(question);
         questionRepository.updateAvailability(id, available);
     }
 

--- a/src/main/java/com/team4/testingsystem/services/impl/RestrictionsServiceImpl.java
+++ b/src/main/java/com/team4/testingsystem/services/impl/RestrictionsServiceImpl.java
@@ -172,7 +172,7 @@ public class RestrictionsServiceImpl implements RestrictionsService {
     @Override
     public void checkModuleIsNotListening(Question question) {
         if (question.getModule().getName().equals(Modules.LISTENING.getName())) {
-            throw new AccessControlException("You can't add one listening question to archive");
+            throw new AccessControlException("You can't archive one listening question");
         }
     }
 

--- a/src/main/java/com/team4/testingsystem/services/impl/RestrictionsServiceImpl.java
+++ b/src/main/java/com/team4/testingsystem/services/impl/RestrictionsServiceImpl.java
@@ -1,6 +1,7 @@
 package com.team4.testingsystem.services.impl;
 
 import com.team4.testingsystem.entities.Answer;
+import com.team4.testingsystem.entities.ContentFile;
 import com.team4.testingsystem.entities.Question;
 import com.team4.testingsystem.entities.Test;
 import com.team4.testingsystem.entities.User;
@@ -11,6 +12,7 @@ import com.team4.testingsystem.exceptions.AssignmentFailException;
 import com.team4.testingsystem.exceptions.CoachAssignmentFailException;
 import com.team4.testingsystem.exceptions.IllegalGradeException;
 import com.team4.testingsystem.exceptions.QuestionNotFoundException;
+import com.team4.testingsystem.exceptions.QuestionOrTopicEditingException;
 import com.team4.testingsystem.exceptions.TestAlreadyStartedException;
 import com.team4.testingsystem.repositories.TestsRepository;
 import com.team4.testingsystem.services.RestrictionsService;
@@ -184,6 +186,20 @@ public class RestrictionsServiceImpl implements RestrictionsService {
 
         if (answers.stream().filter(Answer::isCorrect).count() != 1) {
             throw new AnswersAreBadException("Question must have 1 correct answer");
+        }
+    }
+
+    @Override
+    public void checkNotArchivedQuestion(Question question) {
+        if (!question.isAvailable()) {
+            throw new QuestionOrTopicEditingException("You can't edit unavailable question");
+        }
+    }
+
+    @Override
+    public void checkNotArchivedContentFile(ContentFile contentFile) {
+        if (!contentFile.isAvailable()) {
+            throw new QuestionOrTopicEditingException("You can't edit unavailable topic");
         }
     }
 }

--- a/src/main/java/com/team4/testingsystem/services/impl/RestrictionsServiceImpl.java
+++ b/src/main/java/com/team4/testingsystem/services/impl/RestrictionsServiceImpl.java
@@ -1,10 +1,12 @@
 package com.team4.testingsystem.services.impl;
 
+import com.team4.testingsystem.entities.Answer;
 import com.team4.testingsystem.entities.Question;
 import com.team4.testingsystem.entities.Test;
 import com.team4.testingsystem.entities.User;
 import com.team4.testingsystem.enums.Modules;
 import com.team4.testingsystem.enums.Status;
+import com.team4.testingsystem.exceptions.AnswersAreBadException;
 import com.team4.testingsystem.exceptions.AssignmentFailException;
 import com.team4.testingsystem.exceptions.CoachAssignmentFailException;
 import com.team4.testingsystem.exceptions.IllegalGradeException;
@@ -17,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.security.AccessControlException;
+import java.util.List;
 
 @Service
 public class RestrictionsServiceImpl implements RestrictionsService {
@@ -166,4 +169,21 @@ public class RestrictionsServiceImpl implements RestrictionsService {
         }
     }
 
+    @Override
+    public void checkModuleIsNotListening(Question question) {
+        if (question.getModule().getName().equals(Modules.LISTENING.getName())) {
+            throw new AccessControlException("You can't add one listening question to archive");
+        }
+    }
+
+    @Override
+    public void checkAnswersAreCorrect(List<Answer> answers) {
+        if (answers.size() != 4) {
+            throw new AnswersAreBadException("Question must have 4 answers");
+        }
+
+        if (answers.stream().filter(Answer::isCorrect).count() != 1) {
+            throw new AnswersAreBadException("Question must have 1 correct answer");
+        }
+    }
 }

--- a/src/main/java/com/team4/testingsystem/services/impl/RestrictionsServiceImpl.java
+++ b/src/main/java/com/team4/testingsystem/services/impl/RestrictionsServiceImpl.java
@@ -192,14 +192,14 @@ public class RestrictionsServiceImpl implements RestrictionsService {
     @Override
     public void checkNotArchivedQuestion(Question question) {
         if (!question.isAvailable()) {
-            throw new QuestionOrTopicEditingException("You can't edit unavailable question");
+            throw new QuestionOrTopicEditingException("You can't edit archived questions");
         }
     }
 
     @Override
     public void checkNotArchivedContentFile(ContentFile contentFile) {
         if (!contentFile.isAvailable()) {
-            throw new QuestionOrTopicEditingException("You can't edit unavailable topic");
+            throw new QuestionOrTopicEditingException("You can't edit archived topics");
         }
     }
 }

--- a/src/test/java/com/team4/testingsystem/services/impl/QuestionServiceImplTest.java
+++ b/src/test/java/com/team4/testingsystem/services/impl/QuestionServiceImplTest.java
@@ -112,12 +112,16 @@ class QuestionServiceImplTest {
 
     @Test
     void updateQuestion() {
-        Question question = EntityCreatorUtil.createQuestion();
-        Mockito.when(questionRepository.save(question)).thenReturn(question);
-        Question result = questionService.updateQuestion(question, ID);
+        Mockito.when(questionRepository.findById(ID)).thenReturn(Optional.of(question));
 
+
+        Question question1 = EntityCreatorUtil.createQuestion();
+        Mockito.when(questionRepository.save(question1)).thenReturn(question1);
+        Question result = questionService.updateQuestion(question1, ID);
+
+        verify(restrictionsService).checkNotArchivedQuestion(question);
         verify(questionRepository).updateAvailability(ID, UNAVAILABLE);
-        Assertions.assertEquals(question, result);
+        Assertions.assertEquals(question1, result);
     }
 
     @Test

--- a/src/test/java/com/team4/testingsystem/services/impl/RestrictionsServiceImplTest.java
+++ b/src/test/java/com/team4/testingsystem/services/impl/RestrictionsServiceImplTest.java
@@ -1,11 +1,13 @@
 package com.team4.testingsystem.services.impl;
 
+import com.team4.testingsystem.entities.Answer;
 import com.team4.testingsystem.entities.Module;
 import com.team4.testingsystem.entities.Question;
 import com.team4.testingsystem.entities.Test;
 import com.team4.testingsystem.entities.User;
 import com.team4.testingsystem.enums.Modules;
 import com.team4.testingsystem.enums.Status;
+import com.team4.testingsystem.exceptions.AnswersAreBadException;
 import com.team4.testingsystem.exceptions.AssignmentFailException;
 import com.team4.testingsystem.exceptions.CoachAssignmentFailException;
 import com.team4.testingsystem.exceptions.IllegalGradeException;
@@ -24,6 +26,10 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.security.AccessControlException;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)
 public class RestrictionsServiceImplTest {
@@ -34,7 +40,13 @@ public class RestrictionsServiceImplTest {
     Test test;
 
     @Mock
+    Stream<Answer> stream;
+
+    @Mock
     Question question;
+
+    @Mock
+    List<Answer> answers;
 
     @Mock
     Module module;
@@ -191,7 +203,7 @@ public class RestrictionsServiceImplTest {
     }
 
     @org.junit.jupiter.api.Test
-    void checkNotSelfDeassignAdmin(){
+    void checkNotSelfDeassignAdmin() {
         Mockito.when(test.getUser()).thenReturn(user);
 
         Mockito.when(user.getId()).thenReturn(GOOD_USER_ID);
@@ -206,5 +218,37 @@ public class RestrictionsServiceImplTest {
         }
     }
 
+    @org.junit.jupiter.api.Test
+    void checkModuleIsNotListening() {
+        Mockito.when(question.getModule()).thenReturn(module);
+
+        Mockito.when(module.getName()).thenReturn(Modules.LISTENING.getName());
+
+        Assertions.assertThrows(AccessControlException.class,
+                () -> restrictionsService.checkModuleIsNotListening(question));
+    }
+
+    @org.junit.jupiter.api.Test
+    void checkAnswersAreCorrectNotFourAnswers() {
+        Mockito.when(answers.size()).thenReturn(5);
+
+        Assertions.assertThrows(AnswersAreBadException.class,
+                () -> restrictionsService.checkAnswersAreCorrect(answers));
+    }
+
+    @org.junit.jupiter.api.Test
+    void checkAnswersAreCorrectNotOneCorrect(){
+
+        Mockito.when(answers.size()).thenReturn(4);
+
+        Mockito.when(answers.stream()).thenReturn(stream);
+
+        Mockito.when(stream.filter(any())).thenReturn(stream);
+
+        Mockito.when(stream.count()).thenReturn(0L);
+
+        Assertions.assertThrows(AnswersAreBadException.class,
+                () -> restrictionsService.checkAnswersAreCorrect(answers));
+    }
 
 }

--- a/src/test/java/com/team4/testingsystem/services/impl/RestrictionsServiceImplTest.java
+++ b/src/test/java/com/team4/testingsystem/services/impl/RestrictionsServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.team4.testingsystem.services.impl;
 
 import com.team4.testingsystem.entities.Answer;
+import com.team4.testingsystem.entities.ContentFile;
 import com.team4.testingsystem.entities.Module;
 import com.team4.testingsystem.entities.Question;
 import com.team4.testingsystem.entities.Test;
@@ -12,6 +13,7 @@ import com.team4.testingsystem.exceptions.AssignmentFailException;
 import com.team4.testingsystem.exceptions.CoachAssignmentFailException;
 import com.team4.testingsystem.exceptions.IllegalGradeException;
 import com.team4.testingsystem.exceptions.QuestionNotFoundException;
+import com.team4.testingsystem.exceptions.QuestionOrTopicEditingException;
 import com.team4.testingsystem.exceptions.TestAlreadyStartedException;
 import com.team4.testingsystem.repositories.TestsRepository;
 import com.team4.testingsystem.security.CustomUserDetails;
@@ -38,6 +40,9 @@ public class RestrictionsServiceImplTest {
 
     @Mock
     Test test;
+
+    @Mock
+    ContentFile contentFile;
 
     @Mock
     Stream<Answer> stream;
@@ -251,4 +256,20 @@ public class RestrictionsServiceImplTest {
                 () -> restrictionsService.checkAnswersAreCorrect(answers));
     }
 
+    @org.junit.jupiter.api.Test
+    void checkNotArchivedQuestion(){
+        Mockito.when(question.isAvailable()).thenReturn(false);
+
+        Assertions.assertThrows(QuestionOrTopicEditingException.class,
+                () -> restrictionsService.checkNotArchivedQuestion(question));
+    }
+
+
+    @org.junit.jupiter.api.Test
+    void checkNotArchivedContentFile(){
+        Mockito.when(contentFile.isAvailable()).thenReturn(false);
+
+        Assertions.assertThrows(QuestionOrTopicEditingException.class,
+                () -> restrictionsService.checkNotArchivedContentFile(contentFile));
+    }
 }


### PR DESCRIPTION
Added restrictions which don't allow to:
* Archive one listening question
*  Edit archived questions/topics
*  Add questions not with 4 answers
*  Add questions not with 1 correct answer